### PR TITLE
Support new "generations" of existing segments

### DIFF
--- a/common/src/main/java/io/druid/timeline/SegmentGenerationUtils.java
+++ b/common/src/main/java/io/druid/timeline/SegmentGenerationUtils.java
@@ -1,5 +1,22 @@
 package io.druid.timeline;
 
+/**
+ * A segment with version containing _gen_ is considered to be a new generation of an existing segment, and the version
+ * it is generated from (source version) matches the part before _gen_.
+ * <p>
+ * A generated segment has the following properties:
+ * <ul>
+ *   <li>
+ *     It overshadows its base version segments per partition - if there is no generated segment with a specific
+ *     partition number, then the source version segment with that partition is active.
+ *   </li>
+ *   <li>
+ *     Its version is not used for allocating new segments internally - if it is the latest version for an interval,
+ *     then the segment is allocated to the source version instead. Due to the previous property, the new allocated
+ *     segment would still be active until a generated version of the same partition is created.
+ *   </li>
+ * </ul>
+ */
 public class SegmentGenerationUtils
 {
   /**

--- a/common/src/main/java/io/druid/timeline/SegmentGenerationUtils.java
+++ b/common/src/main/java/io/druid/timeline/SegmentGenerationUtils.java
@@ -1,0 +1,19 @@
+package io.druid.timeline;
+
+public class SegmentGenerationUtils
+{
+  /**
+   * In case the given version string represents a custom generation of some base version, returns that base version.
+   * Otherwise returns <code>null</code>.
+   */
+  public static String getSourceVersion(String version)
+  {
+    int generationIndex = version.indexOf("_gen_");
+
+    if (generationIndex >= 0) {
+      return version.substring(0, generationIndex);
+    } else {
+      return null;
+    }
+  }
+}

--- a/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
+++ b/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
@@ -604,6 +604,7 @@ public class VersionedIntervalTimeline<VersionType, ObjectType> implements Timel
     // For each timeline entry, add partitions from the source version that do not exist for the existing timeline
     // object. These are added as a separate entry to the list.
 
+    // Iterate only the initial items, more items may be added during iteration.
     for (int i = 0; i < initialSize; i++) {
       TimelineObjectHolder<VersionType, ObjectType> latestVersion = holders.get(i);
       VersionType sourceVersion = getSourceVersion(latestVersion.getVersion());

--- a/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
+++ b/common/src/main/java/io/druid/timeline/VersionedIntervalTimeline.java
@@ -277,6 +277,9 @@ public class VersionedIntervalTimeline<VersionType, ObjectType> implements Timel
         VersionType sourceVersion = getSourceVersion(entry.getValue().getVersion());
         TimelineEntry sourceEntry = sourceVersion != null ? versionEntry.get(sourceVersion) : null;
 
+        // If there is a source version entry present in the overshadowed segment map, filter its partitions to exclude
+        // the segments that are not present in this version, as they can be present in the return value of lookup due
+        // to partitions from source version explicitly being added if they are missing from generated version.
         if (sourceEntry != null) {
           PartitionHolder<ObjectType> overshadowedSourceChunks = new PartitionHolder<>(Collections.emptyList());
 

--- a/common/src/main/java/io/druid/timeline/partition/NumberedPartitionChunk.java
+++ b/common/src/main/java/io/druid/timeline/partition/NumberedPartitionChunk.java
@@ -96,8 +96,8 @@ public class NumberedPartitionChunk<T> implements PartitionChunk<T>
     if (other instanceof NumberedPartitionChunk) {
       final NumberedPartitionChunk castedOther = (NumberedPartitionChunk) other;
       return ComparisonChain.start()
-                            .compare(chunks, castedOther.chunks)
                             .compare(chunkNumber, castedOther.chunkNumber)
+                            .compare(chunks, castedOther.chunks)
                             .result();
     } else {
       throw new IllegalArgumentException("Cannot compare against something that is not a NumberedPartitionChunk.");

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorCleanupOvershadowed.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorCleanupOvershadowed.java
@@ -78,7 +78,8 @@ public class DruidCoordinatorCleanupOvershadowed implements DruidCoordinatorHelp
       //Remove all segments in db that are overshadowed by served segments
       for (DataSegment dataSegment : params.getAvailableSegments()) {
         VersionedIntervalTimeline<String, DataSegment> timeline = timelines.get(dataSegment.getDataSource());
-        if (timeline != null && timeline.isOvershadowed(dataSegment.getInterval(), dataSegment.getVersion())) {
+        if (timeline != null && timeline.isOvershadowed(dataSegment.getInterval(), dataSegment.getVersion(),
+            dataSegment.getShardSpec().getPartitionNum())) {
           coordinator.removeSegment(dataSegment);
           stats.addToGlobalStat("overShadowedCount", 1);
         }


### PR DESCRIPTION
A segment with version containing `_gen_` is considered to be a new generation of an existing segment, and the version it is generated from (source version) matches the part before `_gen_`.

A generated segment has the following properties:
* It overshadows its base version segments per partition - if there is no generated segment with a specific partition number, then the source version segment with that partition is active.
* Its version is not used for allocating new segments internally - if it is the latest version for an interval, then the segment is allocated to the source version instead. Due to the previous property, the new allocated segment would still be active until a generated version of the same partition is created.

Additionally changed the default ordering of numbered partitions - the partition number now has a higher priority in comparisons than the core partition count. Before, if you had segments with `(partitionNumber, corePartitionCount)` of `(0, 2), (1, 2), (2,0)`, this would not have been considered a complete set of partitions since they were sorted to and verified in the order `(2,0), (0, 2), (1, 2)`.